### PR TITLE
icu: Fix Kurdish Arabic locale detection

### DIFF
--- a/icu4c/source/data/misc/likelySubtags.txt
+++ b/icu4c/source/data/misc/likelySubtags.txt
@@ -256,6 +256,7 @@ likelySubtags:table(nofallback){
     ksh{"ksh_Latn_DE"}
     ku{"ku_Latn_TR"}
     ku_Arab{"ku_Arab_IQ"}
+    ku_IQ{"ku_Arab_IQ"}
     ku_IR{"ku_Arab_IR"}
     ku_LB{"ku_Arab_LB"}
     kum{"kum_Cyrl_RU"}


### PR DESCRIPTION
- Android 5.0+ supports ISO 639-2 naming but still doesn't support
  more complex locale naming like ku-sArab-rIQ
- Add back the deprecated ku-rIQ locale from older ICU versions
  to workaround the issue, like we used to do in android 4.4

Change-Id: Id1cc22e8cf3d7bd4a57affe401def1797a081289
